### PR TITLE
fix: errors with collecting emojis and img

### DIFF
--- a/utils/crawler/blog_content_crawler.py
+++ b/utils/crawler/blog_content_crawler.py
@@ -56,7 +56,10 @@ def get_blog_content_data(soup, url): # 네이버 블로그 아티클 정보 크
         os.makedirs('data/img', exist_ok=True)
         img_save_dir = os.path.join('data/img', a_id)
         img_urls = d['img_urls']
+        img_urls.extend(d['emoji_urls']) # 이미지와 이모지를 모두 수집하게 함.
         # print("이미지 저장 path:", img_save_dir)
+        # print("이미지 저장 path:", img_save_dir)
+        # print("img_urls", '\n'.join(img_urls))
         download_images(img_urls, img_save_dir)
 
     except NoSuchElementException as e:

--- a/utils/functions/blog_content/image.py
+++ b/utils/functions/blog_content/image.py
@@ -29,14 +29,15 @@ def img_emoji_urls(soup): #bs4 객체가 들어오면, 이미지 개수, 이모�
             if match.group(1) == "postfiles": # 이미지 유형
                 url = update_url_type_param(url, "w580")  # 이미지 블러처리 해제
                 img_urls.append(url)
-            elif  match.group(1) == "storep-phinf": # 이모지 유형
+            elif match.group(1) == "storep-phinf": # 이모지 유형
                 emojis_url.append(url)
         # 그 외 경우 -> 이미지 ?
         else:
             if url.startswith("https://"): # data: 로 시작하는
                 img_urls.append(url)
 
-    d = {"img_cnt": len(img_urls), "img_urls": img_urls, "emoji_cnt": num_emojis}
+    d = {"img_cnt": len(img_urls), "img_urls": img_urls, "emoji_cnt": num_emojis, "emoji_urls":emojis_url}
+
     return d # 딕셔너리
 
 def download_images(img_urls, save_dir):
@@ -44,14 +45,12 @@ def download_images(img_urls, save_dir):
     if not os.path.exists(save_dir):
         os.makedirs(save_dir)
 
-    for url in img_urls:
+    for index, url in enumerate(img_urls):
         # print("이미지 url:", url)
-        # 파일명 추출 (기본적으로 URL에서 마지막 부분 사용)
-        filename = url.split("/")[-1].split("?")[0].split('.')[0]
         img_format = '.jpg'
-        file_path = os.path.join(save_dir, filename+img_format)
+        file_path = os.path.join(save_dir, str(index) + img_format)
         # print(save_dir, filename, img_format)
-        # print("file_path:", file_path)
+        print("file_path:", file_path)
 
         try:
             # 이미지 다운로드

--- a/utils/functions/blog_content_meta/img_emoji_urls.py
+++ b/utils/functions/blog_content_meta/img_emoji_urls.py
@@ -19,11 +19,22 @@ def update_url_type_param(url, new_type_value): # url에서 type 파라미터 �
 def img_emoji_urls(soup): #bs4 객체가 들어오면, 이미지 개수, 이모지 개수, 이모지
     # 이미지 데이터 가져오기
     img_urls = []  # 이미지 링크
-    emojis_url = []  # 이모지 URL 리스트
+    emoji_urls = []  # 이모지 URL 리스트
     num_emojis = 0  # 이모지 개수
-    img_candidates = [img['src'] for img in soup.find_all('img') if img.get('src')]
-    # for img_candidate in img_candidates:
-    #     print(img_candidate + '\n')
+
+    # 이미지 찾기
+    img_candidates = []
+    # 1) 'se-main-container' 클래스를 가진 div 찾기
+    main_container_div = soup.find('div', class_='se-main-container')
+    # img_candidates = [img['src'] for img in soup.find_all('img') if img.get('src')]
+
+    # 2) main_container_div 내부의 모든 img 태그의 src 속성 추출
+    if main_container_div:
+        img_candidates = [img.get('src') for img in main_container_div.find_all('img') if img.get('src')]
+
+    """print(f"len(img_candidates):{len(img_candidates)}\n")
+    for img_candidate in img_candidates:
+         print(img_candidate + '\n')"""
 
     for url in img_candidates:
         match = re.match(r"^https://([^\.]+)\.pstatic\.net/", url)
@@ -32,12 +43,12 @@ def img_emoji_urls(soup): #bs4 객체가 들어오면, 이미지 개수, 이모�
                 url = update_url_type_param(url, "w580")  # 이미지 블러처리 해제
                 img_urls.append(url)
             elif  match.group(1) == "storep-phinf": # 이모지 유형
-                emojis_url.append(url)
+                emoji_urls.append(url)
         # 그 외 경우
         else:
-            if url.startswith("https://"): # data: 로 시작하는
-                img_urls.append(url)
-    num_emojis = len(emojis_url)
+            #if url.startswith("https://") or url.startswith("http://"): # data: 로 시작하는
+            img_urls.append(url)
+    num_emojis = len(emoji_urls)
 
     # print("num of imgs:", len(img_urls))
     # print(f"- 처음 이미지 URL:{img_urls[0]}, 마지막 이미지 URL: {img_urls[-1]}")
@@ -45,7 +56,7 @@ def img_emoji_urls(soup): #bs4 객체가 들어오면, 이미지 개수, 이모�
     #     print(f"{url}\n")"""
     # print("num of emojis", num_emojis)
 
-    d = {"img_cnt": len(img_urls), "img_urls": img_urls, "emoji_cnt": num_emojis}
+    d = {"img_cnt": len(img_urls), "img_urls": img_urls, "emoji_cnt": num_emojis, "emoji_urls": emoji_urls}
     return d # 딕셔너리
 
 def download_images(img_urls, save_dir):
@@ -53,12 +64,11 @@ def download_images(img_urls, save_dir):
     if not os.path.exists(save_dir):
         os.makedirs(save_dir)
 
-    for url in img_urls:
+    for index, url in enumerate(img_urls):
         # print("이미지 url:", url)
         # 파일명 추출 (기본적으로 URL에서 마지막 부분 사용)
-        filename = url.split("/")[-1].split("?")[0].split('.')[0]
         img_format = '.jpg'
-        file_path = os.path.join(save_dir, filename+img_format)
+        file_path = os.path.join(save_dir, str(index+1) + img_format)
         # print(save_dir, filename, img_format)
         # print("file_path:", file_path)
 


### PR DESCRIPTION
# 주요 수정 사항
## 1. 이모지 이미지 데이터 다운로드 되도록 변경 
`img_emoji_urls.py` :  반환 값에 `emoji_urls` 키 추가

```
d = {"img_cnt": len(img_urls), "img_urls": img_urls, "emoji_cnt": num_emojis, "emoji_urls": emoji_urls}
    return d # 딕셔너리`

```
`blog_content_crawler.py`
```
# 이미지 데이터(경로) 수집
        os.makedirs('data/img', exist_ok=True)
        img_save_dir = os.path.join('data/img', a_id)
        img_urls = d['img_urls']
        img_urls.extend(d['emoji_urls']) # 추가: 이미지와 이모지를 모두 수집하게 함.
```

## 3. 일부 이미지 수집되지 않는 문제 해결 (이미지 배너)
기존: 네이버에서 포스팅하는 이미지/이모지 제외하고 https://로 시작하는 이미지만 수집 
문제: 일부 광고 배너 이미지들 http://로 시작 
해결: https:// 필터링 없앰 

`img_emoji_urls.py`

```
        else:
            #if url.startswith("https://") or url.startswith("http://"): # 주석 처리
            img_urls.append(url)
```
## 4. 블로그 본문 내 이미지/이모지만 수집되도록 변경 
`img_emoji_urls.py`
```
# 이미지 찾기
    img_candidates = []
    # 1) 'se-main-container' 클래스를 가진 div 찾기 -> 본문 데이터
    main_container_div = soup.find('div', class_='se-main-container')
    # img_candidates = [img['src'] for img in soup.find_all('img') if img.get('src')]
 ```

# 기타 
5.  이미지 저장 이름 수정 (1.jpg, 2.jpg로 변경)