### PR TITLE
fix: 블로그 포스트 이미지들의 URL 저장

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ try:
     is_first = True
     for area in area_list:
         keyword = area + " 맛집 리뷰"
+        #keyword = "내돈내산 "+ area + " 맛집 리뷰" # 진짜 리뷰 키워드 서칭
         print(keyword)
         print()
         urls = get_blog_links(keyword)
@@ -88,7 +89,7 @@ try:
             print(f"블로그 사용자 id  -  *블로그 id : {blog_id}  *사용자 id : {writer_id}")
 
             # 1. blog_content : 포스트 컨텐츠 데이터 (포스트 내 이미지 개수, 포스트 내 이모지 개수는 여기서 크롤링함 !)
-            title, text_save_path, img_save_dir, img_cnt, emoji_cnt, title_len, whole_text_len = get_blog_content_data(soup, url)
+            title, text_save_path, img_save_dir, img_cnt, emoji_cnt, title_len, whole_text_len, img_urls = get_blog_content_data(soup, url)
             print(f"포스트 컨텐츠 데이터  -  *제목 : {title}  *본문 url : {text_save_path}   *이미지 url : {img_save_dir}    *이미지 개수 : {img_cnt}  *이모지 개수 : {emoji_cnt}")
             print(f"                    *제목 길이 : {title_len}     *본문 길이 : {whole_text_len}")
 
@@ -110,7 +111,7 @@ try:
                 "blog_id": blog_id,
                 "writer_id": writer_id,
                 "title": title,
-                "text_save_path": text_save_path
+                "text_save_path": text_save_path,
             }
             post_content_data_df = pd.DataFrame([post_content_data])
             post_content_data_df.index = [get_next_index(post_content_path)]  # 다음 인덱스 설정
@@ -127,7 +128,8 @@ try:
                 "img_cnt": img_cnt,
                 "emoji_cnt": emoji_cnt,
                 "like_cnt": like_cnt,
-                "comment_cnt": comment_cnt
+                "comment_cnt": comment_cnt,
+                "img_urls": img_urls
             }
             post_meta_data_df = pd.DataFrame([post_meta_data])
             post_meta_data_df.index = [get_next_index(post_meta_path)]  # 다음 인덱스 설정

--- a/utils/crawler/blog_content_crawler.py
+++ b/utils/crawler/blog_content_crawler.py
@@ -69,7 +69,7 @@ def get_blog_content_data(soup, url): # 네이버 블로그 아티클 정보 크
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
 
-    return title, text_save_path, img_save_dir, img_cnt, emoji_cnt, title_len, whole_text_len
+    return title, text_save_path, img_save_dir, img_cnt, emoji_cnt, title_len, whole_text_len, img_urls
 
 if __name__ == "__main__":
     url = "https://blog.naver.com/hj861031/223601136491"

--- a/utils/crawler/blogger_meta_crawler.py
+++ b/utils/crawler/blogger_meta_crawler.py
@@ -5,7 +5,7 @@
 """
 
 from selenium.common import NoSuchElementException, TimeoutException
-
+import re
 def get_blogger_meta_data(soup): # 네이버 블로그 아티클 정보 크롤링하는 함수
     # 변수 기본값 초기화
     intro = ""
@@ -22,6 +22,9 @@ def get_blogger_meta_data(soup): # 네이버 블로그 아티클 정보 크롤�
         '''
         intro = soup.select_one('.caption.align .itemfont.col')
         intro = intro.get_text(strip=True) if intro else None  # 텍스트만 추출하고 None 처리
+        # intro = re.sub(r'&nbsp;', ' ', intro)
+        intro = re.sub(r"\xa0", ' ', intro)
+
 
         # 블로거 배너
         banner = soup.select_one('.itemtitlefont')
@@ -36,7 +39,7 @@ def get_blogger_meta_data(soup): # 네이버 블로그 아티클 정보 크롤�
         menu_cnt = len(soup.find_all(class_='listimage'))  # class명 앞에 `class_` 사용
 
         # 포스트가 속한 메뉴 게시글 개수
-        import re
+
         h4_text = soup.select_one('h4.category_title').get_text() if soup.select_one('h4.category_title') else None
         post_in_menu_cnt = re.search(r'\d{1,3}(?:,\d{3})*', h4_text).group() if h4_text else None  # 정규식 일치 결과 추출
 

--- a/utils/functions/blog_content/text.py
+++ b/utils/functions/blog_content/text.py
@@ -3,15 +3,11 @@ import re
 
 def save_blog_text(file_name, content):
     # 프로젝트 최상위 폴더의 절대 경로를 기준으로 data/txt 경로 설정
-    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-    save_dir = os.path.join(base_dir, 'data', 'txt')
-
+    save_dir = 'data/txt'
     if not os.path.exists(save_dir): # 저장 패스 없으면 여기서 체크
         os.makedirs(save_dir)
         print("no directory!")
-
     save_path = os.path.join(save_dir, file_name)
-    print(save_path)
 
     try:
         with open(save_path + '.txt', "w", encoding="utf-8") as file:


### PR DESCRIPTION
### 📌 작업 내용
블로그 포스트 내 이미지들의 URL들도 저장될 수 있도록 함 
목적: 광고업체 이미지(강남맛집, 레뷰 등)의 링크가 있는지 필터링!

### 🧑‍💻 작업 유형
- [] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] CI/CD 변경

### 📷 관련 이미지
해당 Pull Request와 관련된 이미지가 있을 경우 여기에 첨부해주세요.

### 🚨 주의 사항
csv 파일에 URL이 담긴 리스트가 STRING으로 저장됨. 추후 csv 파일 전처리시 유의해야함
![스크린샷 2024-11-02 오후 2 44 15](https://github.com/user-attachments/assets/da92e6bf-9675-480c-b5c6-9aaeeda04047)


### ✅ 체크 리스트
- [x] 코드 리뷰어가 이해할 수 있도록 주석 및 설명을 추가했습니다.
- [x] 테스트를 추가하거나 업데이트했습니다.
- [x] 문서를 업데이트했습니다 (해당 시).
- [x] 이 변경 사항이 다른 기능에 영향을 미치는지 확인했습니다.
